### PR TITLE
Customization for android notification icon added

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,8 @@ cordova.plugins.backgroundMode.setDefaults({
     title:  String,
     ticker: String,
     text:   String,
-	icon:	String
+	icon:	String,
+	smallIcon:	String
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -201,13 +201,14 @@ document.addEventListener('deviceready', function () {
 To indicate that the app is executing tasks in background and being paused would disrupt the user, the plug-in has to create a notification while in background - like a download progress bar.
 
 #### Override defaults
-The title, ticker and text for that notification can be customized as follows:
+The title, ticker, text and icon for that notification can be customized as follows:
 
 ```javascript
 cordova.plugins.backgroundMode.setDefaults({
     title:  String,
     ticker: String,
-    text:   String
+    text:   String,
+	icon:	String
 })
 ```
 

--- a/src/android/ForegroundService.java
+++ b/src/android/ForegroundService.java
@@ -166,12 +166,13 @@ public class ForegroundService extends Service {
      *      The resource ID of the app icon
      */
     private int getIconResId() {
+        JSONObject settings = BackgroundMode.getSettings();
         Context context = getApplicationContext();
         Resources res   = context.getResources();
         String pkgName  = context.getPackageName();
 
         int resId;
-        resId = res.getIdentifier("icon", "drawable", pkgName);
+        resId = res.getIdentifier(settings.optString("icon", "icon"), "drawable", pkgName);
 
         return resId;
     }

--- a/src/android/ForegroundService.java
+++ b/src/android/ForegroundService.java
@@ -37,6 +37,7 @@ import android.os.Build;
 import android.os.Handler;
 import android.os.IBinder;
 import android.util.Log;
+import android.graphics.BitmapFactory;
 
 /**
  * Puts the service in a foreground state, where the system considers it to be
@@ -139,7 +140,8 @@ public class ForegroundService extends Service {
             .setContentText(settings.optString("text", ""))
             .setTicker(settings.optString("ticker", ""))
             .setOngoing(true)
-            .setSmallIcon(getIconResId());
+			.setLargeIcon(BitmapFactory.decodeResource(getApplicationContext().getResources(), getIconResId()))
+            .setSmallIcon(getSmallIconResId());
 
         if (intent != null && settings.optBoolean("resume")) {
 
@@ -173,6 +175,24 @@ public class ForegroundService extends Service {
 
         int resId;
         resId = res.getIdentifier(settings.optString("icon", "icon"), "drawable", pkgName);
+
+        return resId;
+    }
+
+    /**
+     * Retrieves the resource ID of the app icon.
+     *
+     * @return
+     *      The resource ID of the app icon
+     */
+    private int getSmallIconResId() {
+        JSONObject settings = BackgroundMode.getSettings();
+        Context context = getApplicationContext();
+        Resources res   = context.getResources();
+        String pkgName  = context.getPackageName();
+
+        int resId;
+        resId = res.getIdentifier(settings.optString("smallIcon", "icon"), "drawable", pkgName);
 
         return resId;
     }

--- a/www/background-mode.js
+++ b/www/background-mode.js
@@ -65,7 +65,8 @@ exports._defaults = {
     text:   'Doing heavy tasks.',
     ticker: 'App is running in background',
     resume: true,
-    silent: false
+    silent: false,
+	icon: 'icon'
 };
 
 

--- a/www/background-mode.js
+++ b/www/background-mode.js
@@ -66,7 +66,8 @@ exports._defaults = {
     ticker: 'App is running in background',
     resume: true,
     silent: false,
-	icon: 'icon'
+	icon: 'icon',
+	smallIcon: 'icon'
 };
 
 


### PR DESCRIPTION
This is related to issue described in https://github.com/katzer/cordova-plugin-background-mode/issues/72.

With this change you can:
cordova.plugins.backgroundMode.setDefaults({ text: "Text", title: "Title", ticker: "Ticker", icon: "notification" });

Where notification is name of png in your resources folder (used to be hardcoded to icon.png)
