### PR TITLE
Added Windows 10 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The plugin focuses on enterprise-only distribution and may not compliant with al
 - __iOS__ (_including iOS8_)
 - __Android__ _(SDK >=11)_
 - __WP8__
+- __Windows 10__
 
 
 ## Installation
@@ -137,21 +138,21 @@ The `backgroundMode.isEnabled` interface can be used to get the information if t
 cordova.plugins.backgroundMode.isEnabled(); // => boolean
 ```
 
-### Receive if the background mode is active
+### Receive if the background mode is active (Android/iOS only)
 The `backgroundMode.isActive` interface can be used to get the information if the background mode is active.
 
 ```javascript
 cordova.plugins.backgroundMode.isActive(); // => boolean
 ```
 
-### Get informed when the background mode has been activated
+### Get informed when the background mode has been activated (Android/iOS only)
 The `backgroundMode.onactivate` interface can be used to get notified when the background mode has been activated.
 
 ```javascript
 cordova.plugins.backgroundMode.onactivate = function() {};
 ```
 
-### Get informed when the background mode has been deactivated
+### Get informed when the background mode has been deactivated (Android/iOS only)
 The `backgroundMode.ondeactivate` interface can be used to get notified when the background mode has been deactivated.
 
 #### Further informations
@@ -162,7 +163,7 @@ cordova.plugins.backgroundMode.ondeactivate = function() {};
 ```
 
 ### Get informed when the background mode could not been activated
-The `backgroundMode.onfailure` interface can be used to get notified when the background mode could not been activated.
+The `backgroundMode.onfailure` interface can be used to get notified when the background mode could not be activated (Android/iOS) or enabled (Windows 10).
 
 The listener has to be a function and takes the following arguments:
  - errorCode: Error code which describes the error

--- a/plugin.xml
+++ b/plugin.xml
@@ -108,4 +108,19 @@
 
         <source-file src="src/wp8/BackgroundMode.cs" />
     </platform>
+	
+
+	<!-- windows -->
+	<platform name="windows">
+		<config-file target="config.xml" parent="/*">
+			<feature name="BackgroundMode" >
+				<param name="windows-package" value="BackgroundMode"/>
+			</feature>
+		</config-file>
+
+		<js-module src="src/windows/backgroundmodeProxy.js" name="backgroundmodeProxy">
+			<merges target="" />
+		</js-module>
+	</platform>
+
 </plugin>

--- a/src/windows/backgroundmodeProxy.js
+++ b/src/windows/backgroundmodeProxy.js
@@ -1,0 +1,90 @@
+/**
+ *  BackgroundMode plugin for Windows 10 Universal
+ *
+ *  Copyright (c) 2015 Next Wave Software, Inc.
+**/
+var backgroundMode = {
+    extendedSession: null,
+    settings: { text: "Background processing" },
+
+    /**
+     * Called internally to enable background execution.
+     */
+    requestExtendedExecution: function () {
+
+        // Release the current active extended session if we have one.
+        backgroundMode.releaseExtendedExecution();
+
+        // Set up to request an extended session
+        backgroundMode.extendedSession = new Windows.ApplicationModel.ExtendedExecution.ExtendedExecutionSession();
+        backgroundMode.extendedSession.description = backgroundMode.settings.text;
+        backgroundMode.extendedSession.reason = Windows.ApplicationModel.ExtendedExecution.ExtendedExecutionReason.unspecified;
+
+        // When our app is running in the background and returns to the foreground, Windows will revoke our extended session permission.
+        // This is normal, so just request another session.
+        backgroundMode.extendedSession.onrevoked = function (args) {
+            backgroundMode.requestExtendedExecution();
+        };
+
+        // Request the session
+        backgroundMode.extendedSession.requestExtensionAsync().done(
+            function success() {
+                cordova.plugins.backgroundMode.onactivate();
+            },
+            function error(error) {
+                cordova.plugins.backgroundMode.onfailure(0);
+            }
+        );
+    },
+
+    /**
+     * Called internally to disable background execution.
+     */
+    releaseExtendedExecution: function () {
+
+        if (backgroundMode.extendedSession != null) {
+            backgroundMode.extendedSession.close();
+            backgroundMode.extendedSession = null;
+        }
+    }
+};
+
+cordova.commandProxy.add("BackgroundMode", {
+
+    /**
+     * Enables background execution.
+     */
+    // exec(null, null, 'BackgroundMode', 'enable', []);
+    enable: function () {
+
+		// Whenever our app is launched, request permission to continue running in the background the next time Windows wants to suspend us.
+		WinJS.Application.addEventListener("activated", function (args) {
+			if (args.detail.kind === Windows.ApplicationModel.Activation.ActivationKind.launch)
+			    backgroundMode.requestExtendedExecution();
+		});
+	
+		// Whenever Windows tries to suspend us, again request permission to continue running in the background.
+		WinJS.Application.addEventListener("checkpoint", function (args) {
+		    backgroundMode.requestExtendedExecution();
+		});
+    },
+
+    /**
+     * Disables background execution.
+     */
+    // exec(null, null, 'BackgroundMode', 'disable', []);
+    disable: function () {
+
+        backgroundMode.releaseExtendedExecution();
+		cordova.plugins.backgroundMode.ondeactivate();
+    },
+
+    /**
+     * Sets configuration values.
+     */
+    // exec(null, null, 'BackgroundMode', 'configure', [settingsObject, isUpdate]);
+    configure: function (args) {
+
+        backgroundMode.settings = args[0];
+    }
+});

--- a/www/background-mode.js
+++ b/www/background-mode.js
@@ -112,7 +112,7 @@ exports.setDefaults = function (overrides) {
         }
     }
 
-    if (device.platform == 'Android') {
+    if ((device.platform == 'Android') || (device.platform == 'Windows')){
         cordova.exec(null, null, 'BackgroundMode', 'configure', [defaults, false]);
     }
 };
@@ -127,7 +127,7 @@ exports.setDefaults = function (overrides) {
 exports.configure = function (options) {
     var settings = this.mergeWithDefaults(options);
 
-    if (device.platform == 'Android') {
+    if ((device.platform == 'Android') || (device.platform == 'Windows')){
         cordova.exec(null, null, 'BackgroundMode', 'configure', [settings, true]);
     }
 };


### PR DESCRIPTION
Added Windows 10 support to the plugin, updated README.MD accordingly. Background support works a bit differently in Windows 10 than Android/iOS in that the app requests permission to run in background at startup and then when it moves from the foreground to the background it just keeps executing and is not aware that it is in the background. It does, however, get a notification when it moves from the background to the foreground. Tested on Windows 10 and Windows 10 Mobile, seems solid.