### PR TITLE
Change iOS UIBackgroundModes value

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -44,7 +44,7 @@
         <!-- The app is able to run in background through audio mode -->
         <config-file target="*-Info.plist" parent="UIBackgroundModes">
             <array>
-                <string>audio</string>
+                <string>remote-notification</string>
             </array>
         </config-file>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -41,7 +41,7 @@
             </feature>
         </config-file>
 
-        <!-- The app is able to run in background through audio mode -->
+        <!-- The app is able to run in background through remote-notification mode -->
         <config-file target="*-Info.plist" parent="UIBackgroundModes">
             <array>
                 <string>remote-notification</string>


### PR DESCRIPTION
Starting from iOS 7.0 the [UIBackgroundModes](https://developer.apple.com/library/ios/documentation/General/Reference/InfoPlistKeyReference/Articles/iPhoneOSKeys.html#//apple_ref/doc/uid/TP40009252-SW22) value can be set to something different than `audio`.

Given that this plugin's purpose is

> for applications, who rely on continuous network communication independent of from direct user interactions and remote push notifications.

I suggest to change from `audio` to `remote-notification`:

> The app uses remote notifications as a signal that there is new content available for download. When a remote notification arrives, the system launches or resumes the app in the background and gives it a small amount of time to download the new content.

The `audio` value can cause rejection from the Apple store because there is no hearable background audio playing. I still have not removed the relevant audio playback code in `src/ios/APPBackgroundMode.m`, let me know your thoughts.

An alternative value for UIBackgroundModes might be `fetch`:

> The app requires new content from the network on a regular basis. When it is convenient to do so, the system launches or resumes the app in the background and gives it a small amount of time to download any new content.
