### PR TITLE
Fix ios other apps audio interruption

### DIFF
--- a/src/ios/APPBackgroundMode.m
+++ b/src/ios/APPBackgroundMode.m
@@ -150,7 +150,7 @@ NSString *const kAPPBackgroundEventFailure = @"failure";
     AVAudioSession* session = [AVAudioSession
                                sharedInstance];
     // Don't activate the audio session yet
-    [session setActive: NO error:NULL];
+    [session setActive:NO error:NULL];
     // Play music even in background and dont stop playing music
     // even another app starts playing sound
     [session setCategory:AVAudioSessionCategoryPlayback

--- a/src/ios/APPBackgroundMode.m
+++ b/src/ios/APPBackgroundMode.m
@@ -149,13 +149,14 @@ NSString *const kAPPBackgroundEventFailure = @"failure";
 - (void) configureAudioSession {
     AVAudioSession* session = [AVAudioSession
                                sharedInstance];
-
+    // Don't activate the audio session yet
+    [session setActive: NO error:NULL];
     // Play music even in background and dont stop playing music
     // even another app starts playing sound
     [session setCategory:AVAudioSessionCategoryPlayback
              withOptions:AVAudioSessionCategoryOptionMixWithOthers
                    error:NULL];
-
+    // Active the audio session
     [session setActive:YES error:NULL];
 };
 


### PR DESCRIPTION
Other apps audio was interrupted when the background mode was enabled. I found the solution on this post http://stackoverflow.com/questions/10180500/how-to-use-kaudiosessionproperty-overridecategorymixwithothers
If we don't disable the audio session before that the option AVAudioSessionCategoryOptionMixWithOthers is set, it interrupts the other apps audio. Because the category 'AVAudioSessionCategoryPlayback' is set and by default the session is already active and this category interrupts other apps audio without the option 'mix with others'.