### PR TITLE
bug(android): update notification instead of recreating

### DIFF
--- a/src/android/ForegroundService.java
+++ b/src/android/ForegroundService.java
@@ -174,7 +174,7 @@ public class ForegroundService extends Service {
         Intent intent   = context.getPackageManager()
                 .getLaunchIntentForPackage(pkgName);
 
-        if(!isUpdate || this.notificationBuilder == null){
+        if(!isUpdate || notificationBuilder == null){
             notificationBuilder = new Notification.Builder(context)
                     .setOngoing(true)
                     .setSmallIcon(getIconResId(settings));

--- a/src/android/ForegroundService.java
+++ b/src/android/ForegroundService.java
@@ -168,6 +168,7 @@ public class ForegroundService extends Service {
         String title    = settings.optString("title", NOTIFICATION_TITLE);
         String text     = settings.optString("text", NOTIFICATION_TEXT);
         boolean bigText = settings.optBoolean("bigText", false);
+        boolean onlyAlertOnce = settings.optBoolean("onlyAlertOnce", false);
 
         Context context = getApplicationContext();
         String pkgName  = context.getPackageName();
@@ -176,7 +177,8 @@ public class ForegroundService extends Service {
 
         if(!isUpdate || notificationBuilder == null){
             notificationBuilder = new Notification.Builder(context)
-                    .setOngoing(true);
+                    .setOngoing(true)
+                    .setOnlyAlertOnce(onlyAlertOnce);
         }
 
         notificationBuilder.setContentTitle(title)

--- a/src/android/ForegroundService.java
+++ b/src/android/ForegroundService.java
@@ -176,12 +176,12 @@ public class ForegroundService extends Service {
 
         if(!isUpdate || notificationBuilder == null){
             notificationBuilder = new Notification.Builder(context)
-                    .setOngoing(true)
-                    .setSmallIcon(getIconResId(settings));
+                    .setOngoing(true);
         }
 
         notificationBuilder.setContentTitle(title)
-                .setContentText(text);
+                .setContentText(text)
+                .setSmallIcon(getIconResId(settings));
 
         if (settings.optBoolean("hidden", true)) {
             notificationBuilder.setPriority(Notification.PRIORITY_MIN);

--- a/src/android/ForegroundService.java
+++ b/src/android/ForegroundService.java
@@ -64,6 +64,7 @@ public class ForegroundService extends Service {
 
     // Partial wake lock to prevent the app from going to sleep when locked
     private PowerManager.WakeLock wakeLock;
+    private Notification.Builder notificationBuilder;
 
     /**
      * Allow clients to call on to the service.
@@ -153,6 +154,17 @@ public class ForegroundService extends Service {
      * @param settings The config settings
      */
     private Notification makeNotification(JSONObject settings) {
+        return makeNotification(settings, false);
+    }
+
+    /**
+     * Create a notification as the visible part to be able to put the service
+     * in a foreground state.
+     *
+     * @param settings The config settings
+     * @param isUpdate flag indication the settings should only update the notification
+     */
+    private Notification makeNotification(JSONObject settings, boolean isUpdate) {
         String title    = settings.optString("title", NOTIFICATION_TITLE);
         String text     = settings.optString("text", NOTIFICATION_TEXT);
         boolean bigText = settings.optBoolean("bigText", false);
@@ -162,22 +174,25 @@ public class ForegroundService extends Service {
         Intent intent   = context.getPackageManager()
                 .getLaunchIntentForPackage(pkgName);
 
-        Notification.Builder notification = new Notification.Builder(context)
-                .setContentTitle(title)
-                .setContentText(text)
-                .setOngoing(true)
-                .setSmallIcon(getIconResId(settings));
+        if(!isUpdate || this.notificationBuilder == null){
+            notificationBuilder = new Notification.Builder(context)
+                    .setOngoing(true)
+                    .setSmallIcon(getIconResId(settings));
+        }
+
+        notificationBuilder.setContentTitle(title)
+                .setContentText(text);
 
         if (settings.optBoolean("hidden", true)) {
-            notification.setPriority(Notification.PRIORITY_MIN);
+            notificationBuilder.setPriority(Notification.PRIORITY_MIN);
         }
 
         if (bigText || text.contains("\n")) {
-            notification.setStyle(
+            notificationBuilder.setStyle(
                     new Notification.BigTextStyle().bigText(text));
         }
 
-        setColor(notification, settings);
+        setColor(notificationBuilder, settings);
 
         if (intent != null && settings.optBoolean("resume")) {
             PendingIntent contentIntent = PendingIntent.getActivity(
@@ -185,10 +200,10 @@ public class ForegroundService extends Service {
                     PendingIntent.FLAG_UPDATE_CURRENT);
 
 
-            notification.setContentIntent(contentIntent);
+            notificationBuilder.setContentIntent(contentIntent);
         }
 
-        return notification.build();
+        return notificationBuilder.build();
     }
 
     /**
@@ -204,7 +219,7 @@ public class ForegroundService extends Service {
             return;
         }
 
-        Notification notification = makeNotification(settings);
+        Notification notification = makeNotification(settings, true);
         getNotificationManager().notify(NOTIFICATION_ID, notification);
     }
 

--- a/www/background-mode.js
+++ b/www/background-mode.js
@@ -388,6 +388,7 @@ exports._defaults = {
     resume:  true,
     silent:  false,
     hidden:  true,
+    onlyAlertOnce: false,
     color:   undefined,
     icon:    'icon'
 };


### PR DESCRIPTION
On Android the notification will always recreated when updating e.g. the text with `cordova.plugins.backgroundMode.configure({ text: "Upload 2 of 20 images" });`.
 This will result in a flickering notification because the old notification will be replaced with a new one. If you only want to update elements in the notification you have to keep the old `Notification.Builder`. 

I also add a new option called onlyAlertOnce [see `Notification.Builder.html#setOnlyAlertOnce`](https://developer.android.com/reference/android/app/Notification.Builder.html#setOnlyAlertOnce(boolean)). So you can control if the ticker in the notification is triggered on a update. Because of my bad english I don't update the README for this new option.