### PR TITLE
Background Service stuck headless when swiping app away

### DIFF
--- a/src/android/BackgroundMode.java
+++ b/src/android/BackgroundMode.java
@@ -155,6 +155,7 @@ public class BackgroundMode extends CordovaPlugin {
     public void onDestroy() {
         stopService();
         super.onDestroy();
+        android.os.Process.killProcess(android.os.Process.myPid());
     }
 
     /**


### PR DESCRIPTION
As explained in #298 and #261 on some devices the plugin's service would not die if you swiped away the app from the recents screen on Android.

This resulted in periodic logcat errors and problems when you started the app back up again. In my case, i could not re-connect to a BLE device as the connection was still on from the previous run.

This patch seems to fix those problems as it basically does a "force stop" when the app gets swiped away, closing the service as well as everything else.