### PR TITLE
Windows background execution

### DIFF
--- a/DIFFERENCE.md
+++ b/DIFFERENCE.md
@@ -1,0 +1,13 @@
+# Difference from [original repository](https://github.com/katzer/cordova-plugin-background-mode)
+This repository is trying to solve issues with Windows compatibility of original plugin (mainly by finding workarounds for [issue #222](https://github.com/katzer/cordova-plugin-background-mode/issues/222)).
+## Changes
+1. Plugin hook to add windows capability `backgroundMediaPlayback` into windows `*.appxmanifest` files
+1. Usage of `Windows.ApplicationModel.ExtendedExecution` functionality to keep app running when minimized
+1. Starting audio playback automatically (to keep application running; quiet, but playing) - *might have performance & battery impact*
+## Upsides
+1. Plugin works for Windows applications (Desktop windows tested, haven't tested @mobile)
+1. You can pause application background tasks by clicking pause button under application hover-preview in taskbar (side effect of being "media-app")
+## Downsides
+1. Windows target is not buildable by `[ionic] cordova build|run windows` (I suspect that this is another reminiscence of unsupported windows `backgroundMediaPlayback` capability in Cordova - framework validation of `*.appxmanifest` file fails)
+1. When you're removing plugin, capability of `backgroundMediaPlayback` is kept in `*.appxmanifest` files, which means, that app is still not buildable by Cordova CLI (to fix it, remove/readd windows platform to project after plugin removal)
+1. Possible severe performance issues/battery drains, because of continuous unstopped playback

--- a/plugin.xml
+++ b/plugin.xml
@@ -97,10 +97,6 @@
             </feature>
         </config-file>
 
-        <config-file target="package.appxmanifest" parent="/Package/Capabilities" device-target="windows">
-            <Capability Name="backgroundMediaPlayback" />
-        </config-file>
-
         <config-file target="config.xml" parent="/*">
             <preference name="windows-target-version" value="UAP" />
             <preference name="uap-target-min-version" value="10.0.14393.0" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -89,7 +89,7 @@
             target-dir="src/de/appplant/cordova/plugin/background" />
     </platform>
 
-    <!-- windows
+    <!-- windows -->
     <platform name="windows">
         <config-file target="config.xml" parent="/*">
             <feature name="BackgroundMode" >
@@ -113,7 +113,7 @@
         <js-module src="src/windows/BackgroundModeProxy.js" name="BackgroundMode.Proxy">
             <runs />
         </js-module>
-    </platform> -->
+    </platform>
 
     <!-- browser -->
     <platform name="browser">

--- a/plugin.xml
+++ b/plugin.xml
@@ -109,6 +109,9 @@
         <js-module src="src/windows/BackgroundModeProxy.js" name="BackgroundMode.Proxy">
             <runs />
         </js-module>
+
+        <hook src="scripts/hook-windows-background-capability.js" type="after_platform_add" />
+        <hook src="scripts/hook-windows-background-capability.js" type="after_plugin_add" />
     </platform>
 
     <!-- browser -->

--- a/scripts/hook-windows-background-capability.js
+++ b/scripts/hook-windows-background-capability.js
@@ -1,0 +1,111 @@
+#!/usr/bin/env javascript
+
+/*
+  Copyright (c) Microsoft. All rights reserved.
+  Licensed under the MIT license. See LICENSE file in the project root for full license information.
+*/
+var fs = require("fs");
+var path = require("path");
+var Q;
+var glob;
+var xml2js = require('xml2js');
+
+var requiredCapabilities = [
+  {
+    name: "backgroundMediaPlayback",
+    present: false,
+    tag: "uap3:Capability",
+    namespace: { name: "uap3", uri: "http://schemas.microsoft.com/appx/manifest/uap/windows10/3" }
+  } /*, {
+    name: "extendedExecutionUnconstrained",
+    present: false,
+    tag: "rescap:Capability",
+    namespace: {name: "rescap", uri:"http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"}
+  }*/
+];
+
+module.exports = function(context) {
+
+  console.log("Adding proper capability to windows manifests");
+
+  // Grab the Q, glob node modules from cordova
+  Q=context.requireCordovaModule("q");
+  glob=context.requireCordovaModule("glob");
+
+  // Need to return a promise since glob is async
+  var deferred = Q.defer();
+
+  // Find all custom framework files within plugin source code for the iOS platform
+  glob("platforms/windows/package.*.appxmanifest", function(err, manifests) {
+    if(err) {
+      deferred.reject(err);
+    } else {
+      // Folder symlinks like "Header" will appear as normal files without an extension if they came from
+      // npm or were sourced from windows. Inside these files is the relative path to the directory the
+      // symlink points to. So, start detecting them them by finding files < 1k without a file extension.
+      manifests.forEach(function(manifest) {
+        manifest = path.join(context.opts.projectRoot, manifest);
+
+        fs.readFile(manifest, 'utf8', function(err, data) {
+          console.log("Processing:", manifest);
+          if (err) {
+            return console.log(err);
+          }
+
+          xml2js.parseString(data, function(err, xml) {
+            if (err) {
+              return console.log(err);
+            }
+            var capabilities = xml['Package']['Capabilities'][0];
+            if (typeof capabilities === "undefined") {
+              capabilities = {};
+            }
+            // Check if capability is already present
+            requiredCapabilities.forEach(function (req) {
+              if (typeof capabilities[req.tag] !== "undefined") {
+                capabilities[req.tag].forEach(function(capability) {
+                  if (capability["$"] && capability["$"]["Name"] == req.name) {
+                    req.present = true;
+                  }
+                });
+              }
+            });
+
+            requiredCapabilities.forEach(function (req) {
+              if (!req.present) {
+                console.log ("Adding", req.name)
+                if (typeof capabilities[req.tag] === "undefined") {
+                  capabilities[req.tag] = [];
+                }
+                capabilities[req.tag].push({"$": { "Name" : req.name }})
+                if (req.namespace && !xml['Package']['$']['xmlns:' + req.namespace.name]) {
+                  xml['Package']['$']['xmlns:' + req.namespace.name] = req.namespace.uri;
+                }
+              }
+            });
+            var namespaces = [];
+            for (ns in xml['Package']['$']) {
+              if (ns.match(/^xmlns:/)) {
+                namespaces.push(ns.split(":")[1]);
+              }
+            };
+            xml['Package']['$']['IgnorableNamespaces'] = namespaces.join(" ");
+
+            xml['Package']['Capabilities'] = capabilities;
+
+            // write modified appxmanifest
+            var builder = new xml2js.Builder();
+            fs.writeFile(manifest, builder.buildObject(xml), function(err) {
+              if(err) {
+                return console.log(err);
+              }
+            });
+          });
+        });
+      });
+      deferred.resolve();
+    }
+  });
+
+  return deferred.promise;
+}


### PR DESCRIPTION
# Difference from [original repository](https://github.com/katzer/cordova-plugin-background-mode)
This repository is trying to solve issues with Windows compatibility of original plugin (mainly by finding workarounds for [issue #222](https://github.com/katzer/cordova-plugin-background-mode/issues/222)).
## Changes
1. Plugin hook to add windows capability `backgroundMediaPlayback` into windows `*.appxmanifest` files
1. Usage of `Windows.ApplicationModel.ExtendedExecution` functionality to keep app running when minimized
1. Starting audio playback automatically (to keep application running; quiet, but playing) - *might have performance & battery impact*
## Upsides
1. Plugin works for Windows applications (Desktop windows tested, haven't tested @mobile)
1. You can pause application background tasks by clicking pause button under application hover-preview in taskbar (side effect of being "media-app")
## Downsides
1. Windows target is not buildable by `[ionic] cordova build|run windows` (I suspect that this is another reminiscence of unsupported windows `backgroundMediaPlayback` capability in Cordova - framework validation of `*.appxmanifest` file fails)
1. When you're removing plugin, capability of `backgroundMediaPlayback` is kept in `*.appxmanifest` files, which means, that app is still not buildable by Cordova CLI (to fix it, remove/readd windows platform to project after plugin removal)
1. Possible severe performance issues/battery drains, because of continuous unstopped playback
