### PR TITLE
function onactivate does no longer exist

### DIFF
--- a/src/android/BackgroundMode.java
+++ b/src/android/BackgroundMode.java
@@ -294,7 +294,7 @@ public class BackgroundMode extends CordovaPlugin {
         String str = String.format("%s._setActive(%b)",
                 JS_NAMESPACE, active);
 
-        str = String.format("%s;%s.on%s(%s)",
+        str = String.format("%s;%s.on('%s', %s)",
                 str, JS_NAMESPACE, eventName, params);
 
         str = String.format("%s;%s.fireEvent('%s',%s);",


### PR DESCRIPTION
I got the error message that "onactivate" does not exist with the latest HEAD Version. I therefore investigated and found out that since the on() function has been changed, I think this has been forgotten to also be changed in the Java file.