### PR TITLE
Android 9 Fix

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -3,7 +3,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
         id="cordova-plugin-background-mode"
-        version="0.7.2">
+        version="0.7.3">
 
     <name>BackgroundMode</name>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -71,12 +71,13 @@
             <preference name="KeepRunning" value="true" />
         </config-file>
 
-        <config-file target="AndroidManifest.xml" parent="/manifest/application">
+        <config-file target="AndroidManifest.xml" parent="application">
             <service android:name="de.appplant.cordova.plugin.background.ForegroundService" />
         </config-file>
 
         <config-file target="AndroidManifest.xml" parent="/manifest">
             <uses-permission android:name="android.permission.WAKE_LOCK" />
+            <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
         </config-file>
 
         <source-file


### PR DESCRIPTION
Background mode is not working for android 9. As the it would not launch the Foreground service

Based on android documentation FOREGROUND_SERVICE permission is required:

> Note: Apps that target Android 9 (API level 28) or higher and use foreground services must request the FOREGROUND_SERVICE permission. This is a normal permission, so the system automatically grants it to the requesting app.
> 
> If an app that targets API level 28 or higher attempts to create a foreground service without requesting FOREGROUND_SERVICE, the system throws a SecurityException.
[source](https://developer.android.com/guide/components/services)

Also the service was not added correctly to the AndroidManifest.xml