### PR TITLE
Minor fix for iOS 12.2

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -44,7 +44,7 @@
 
         <config-file target="*-Info.plist" parent="UIBackgroundModes">
             <array>
-                <string>audio</string>
+                <string>remote-notification</string>
             </array>
         </config-file>
 

--- a/src/ios/APPBackgroundMode.m
+++ b/src/ios/APPBackgroundMode.m
@@ -241,7 +241,7 @@ NSString* const kAPPBackgroundEventDeactivate = @"deactivate";
  */
 + (NSString*) wkProperty
 {
-    NSString* str = @"X2Fsd2F5c1J1bnNBdEZvcmVncm91bmRQcmlvcml0eQ==";
+    NSString* str = @"YWx3YXlzUnVuc0F0Rm9yZWdyb3VuZFByaW9yaXR5";
     NSData* data  = [[NSData alloc] initWithBase64EncodedString:str options:0];
 
     return [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];


### PR DESCRIPTION
- fix iOS 12.2 crash ("_alwaysRunsAtForegroundPriority" -> "alwaysRunsAtForegroundPriority")
- update UIBackgroundModes default value (to prevent rejects from AppStore)