### PR TITLE
Remove Windows platform from plugin.xml to allow install on cordova >9

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -24,7 +24,6 @@
     <engines>
         <engine name="cordova" version=">=3.0.0" />
         <engine name="android-sdk" version=">=16" />
-        <engine name="windows-sdk" version=">=10.0.14393.0" />
     </engines>
 
     <!-- js -->
@@ -91,32 +90,6 @@
             src="src/android/ForegroundService.java"
             target-dir="src/de/appplant/cordova/plugin/background" />
     </platform>
-
-    <!-- windows
-    <platform name="windows">
-        <config-file target="config.xml" parent="/*">
-            <feature name="BackgroundMode" >
-                <param name="windows-package" value="BackgroundMode"/>
-            </feature>
-        </config-file>
-
-        <config-file target="package.appxmanifest" parent="/Package/Capabilities" device-target="windows">
-            <Capability Name="backgroundMediaPlayback" />
-        </config-file>
-
-        <config-file target="config.xml" parent="/*">
-            <preference name="windows-target-version" value="UAP" />
-            <preference name="uap-target-min-version" value="10.0.14393.0" />
-            <preference name="Windows.Universal-MinVersion" value="10.0.14393.0" />
-            <preference name="Windows.Universal" value="10.0.14393.0" />
-        </config-file>
-
-        <resource-file src="appbeep.wma" target="appbeep.wma" />
-
-        <js-module src="src/windows/BackgroundModeProxy.js" name="BackgroundMode.Proxy">
-            <runs />
-        </js-module>
-    </platform> -->
 
     <!-- browser -->
     <platform name="browser">

--- a/src/ios/APPBackgroundMode.m
+++ b/src/ios/APPBackgroundMode.m
@@ -241,7 +241,7 @@ NSString* const kAPPBackgroundEventDeactivate = @"deactivate";
  */
 + (NSString*) wkProperty
 {
-    NSString* str = @"X2Fsd2F5c1J1bnNBdEZvcmVncm91bmRQcmlvcml0eQ==";
+    NSString* str = @"YWx3YXlzUnVuc0F0Rm9yZWdyb3VuZFByaW9yaXR5";
     NSData* data  = [[NSData alloc] initWithBase64EncodedString:str options:0];
 
     return [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];


### PR DESCRIPTION
As proposed in [this thread](https://github.com/katzer/cordova-plugin-background-mode/issues/441) 