### PR TITLE
Make plugin compatible with java 6

### DIFF
--- a/src/android/BackgroundMode.java
+++ b/src/android/BackgroundMode.java
@@ -90,9 +90,12 @@ public class BackgroundMode extends CordovaPlugin {
      * @return Returning false results in a "MethodNotFound" error.
      */
     @Override
-    public boolean execute(String action, JSONArray args, CallbackContext callback)
+    public boolean execute(String rawAction, JSONArray args, CallbackContext callback)
     {
-        Log.i("BGCORDOVA", "BackgroundMode Executing action: '"+action+"'");
+        String action = rawAction.toLowerCase().trim();
+
+        Log.i("BGCORDOVA", "BackgroundMode Executing action: '"+action+"' rawAction: '"+rawAction+"'");
+
 
         if(action == "configure"){
             JSONObject optJSONObject = args.optJSONObject(0);
@@ -122,7 +125,7 @@ public class BackgroundMode extends CordovaPlugin {
             return true;
         }
 
-        Log.e("BGCORDOVA", "BackgroundMode Invalid action: " + action + " args: " + args + " callback: " + callback );
+        Log.e("BGCORDOVA", "BackgroundMode Invalid action: '" + action + "' args: '" + args + "' callback: '" + callback +"'");
         callback.error("Invalid action: " + action + " args: " + args + " callback: " + callback);
         return false;
     }

--- a/src/android/BackgroundMode.java
+++ b/src/android/BackgroundMode.java
@@ -96,18 +96,37 @@ public class BackgroundMode extends CordovaPlugin {
         Log.i("BGCORDOVA", "Executing action: '"+action+"'");
         boolean validAction = true;
 
-        if(action == "configure") configure(args.optJSONObject(0), args.optBoolean(1));
-        else if(action == "enable") enableMode();
-        else if(action == "disable") disableMode();
-        else validAction = false;
+        if(action == "configure"){
+            JSONObject optJSONObject = args.optJSONObject(0);
+            boolean optBoolean = args.optBoolean(1);
 
-        if (validAction) {
+            Log.i("BGCORDOVA", "BackgroundMode Configure optJSONObject: '"+args.optJSONObject(0)+"' optBoolean: '"+optBoolean+"'");
+
+            configure(optJSONObject, optBoolean);
             callback.success();
-        } else {
-            callback.error("Invalid action: " + action + " args: " + args + " callback: " + callback);
+            return true;
         }
 
-        return validAction;
+        if(action == "enable"){
+
+            Log.i("BGCORDOVA", "BackgroundMode Enable");
+
+            enableMode();
+            callback.success();
+            return true;
+        }
+
+        if(action == "disable"){
+
+            Log.i("BGCORDOVA", "BackgroundMode Disable");
+            disableMode();
+            callback.success();
+            return true;
+        }
+
+        Log.e("BGCORDOVA", "BackgroundModeExt Invalid action: " + action + " args: " + args + " callback: " + callback );
+        callback.error("Invalid action: " + action + " args: " + args + " callback: " + callback);
+        return false;
     }
 
     /**

--- a/src/android/BackgroundMode.java
+++ b/src/android/BackgroundMode.java
@@ -90,16 +90,11 @@ public class BackgroundMode extends CordovaPlugin {
      * @return Returning false results in a "MethodNotFound" error.
      */
     @Override
-    public boolean execute(String rawAction, JSONArray args, CallbackContext callback)
+    public boolean execute(String action, JSONArray args, CallbackContext callback)
     {
-        String action = rawAction.toLowerCase().trim();
+        Log.i("BGCORDOVA", "BackgroundMode Executing action: '"+action+"'");
 
-        Log.i("BGCORDOVA", "BackgroundMode Executing action: '"+action+"' rawAction: '"+rawAction+"'");
-        Log.i("BGCORDOVA", "BackgroundMode Executing action: '"+action+"' rawAction: '"+rawAction+
-                "' action == \"configure\""+(action == "configure")+"  action.equals(\"configure\"): "+(action.equals("configure")));
-
-
-        if(action == "configure"){
+        if(action.equals("configure")){
             JSONObject optJSONObject = args.optJSONObject(0);
             boolean optBoolean = args.optBoolean(1);
 
@@ -110,7 +105,7 @@ public class BackgroundMode extends CordovaPlugin {
             return true;
         }
 
-        if(action == "enable"){
+        if(action.equals("enable")){
 
             Log.i("BGCORDOVA", "BackgroundMode Enable");
 
@@ -119,7 +114,7 @@ public class BackgroundMode extends CordovaPlugin {
             return true;
         }
 
-        if(action == "disable"){
+        if(action.equals("disable")){
 
             Log.i("BGCORDOVA", "BackgroundMode Disable");
             disableMode();

--- a/src/android/BackgroundMode.java
+++ b/src/android/BackgroundMode.java
@@ -247,7 +247,7 @@ public class BackgroundMode extends CordovaPlugin {
      */
     private void startService()
     {
-        Log.i("BGCORDOVA", "BackgroundModeExt startService");
+        Log.d("BGCORDOVA", "BackgroundModeExt startService");
         Activity context = cordova.getActivity();
 
         if (isDisabled || isBind)
@@ -272,7 +272,7 @@ public class BackgroundMode extends CordovaPlugin {
      */
     private void stopService()
     {
-        Log.i("BGCORDOVA", "BackgroundModeExt stopService");
+        Log.d("BGCORDOVA", "BackgroundModeExt stopService");
         Activity context = cordova.getActivity();
         Intent intent    = new Intent(context, ForegroundService.class);
 
@@ -293,7 +293,7 @@ public class BackgroundMode extends CordovaPlugin {
      */
     private void fireEvent (Event event, String params)
     {
-        Log.i("BGCORDOVA", "BackgroundModeExt fireEvent event: '"+event+"' params: '"+params+"'");
+        Log.d("BGCORDOVA", "BackgroundModeExt fireEvent event: '"+event+"' params: '"+params+"'");
         String eventName = event.name().toLowerCase();
         Boolean active   = event == Event.ACTIVATE;
 

--- a/src/android/BackgroundMode.java
+++ b/src/android/BackgroundMode.java
@@ -122,7 +122,7 @@ public class BackgroundMode extends CordovaPlugin {
             return true;
         }
 
-        Log.e("BGCORDOVA", "BackgroundModeExt Invalid action: " + action + " args: " + args + " callback: " + callback );
+        Log.e("BGCORDOVA", "BackgroundMode Invalid action: " + action + " args: " + args + " callback: " + callback );
         callback.error("Invalid action: " + action + " args: " + args + " callback: " + callback);
         return false;
     }
@@ -135,7 +135,7 @@ public class BackgroundMode extends CordovaPlugin {
     @Override
     public void onPause(boolean multitasking)
     {
-        Log.i("BGCORDOVA", "BackgroundModeExt onPause");
+        Log.i("BGCORDOVA", "BackgroundMode onPause");
         try {
             inBackground = true;
             startService();
@@ -149,7 +149,7 @@ public class BackgroundMode extends CordovaPlugin {
      */
     @Override
     public void onStop() {
-        Log.i("BGCORDOVA", "BackgroundModeExt onStop");
+        Log.i("BGCORDOVA", "BackgroundMode onStop");
         clearKeyguardFlags(cordova.getActivity());
     }
 
@@ -161,7 +161,7 @@ public class BackgroundMode extends CordovaPlugin {
     @Override
     public void onResume(boolean multitasking)
     {
-        Log.i("BGCORDOVA", "BackgroundModeExt onResume");
+        Log.i("BGCORDOVA", "BackgroundMode onResume");
         inBackground = false;
         stopService();
     }
@@ -247,7 +247,7 @@ public class BackgroundMode extends CordovaPlugin {
      */
     private void startService()
     {
-        Log.d("BGCORDOVA", "BackgroundModeExt startService");
+        Log.d("BGCORDOVA", "BackgroundMode startService");
         Activity context = cordova.getActivity();
 
         if (isDisabled || isBind)
@@ -272,7 +272,7 @@ public class BackgroundMode extends CordovaPlugin {
      */
     private void stopService()
     {
-        Log.d("BGCORDOVA", "BackgroundModeExt stopService");
+        Log.d("BGCORDOVA", "BackgroundMode stopService");
         Activity context = cordova.getActivity();
         Intent intent    = new Intent(context, ForegroundService.class);
 
@@ -293,7 +293,7 @@ public class BackgroundMode extends CordovaPlugin {
      */
     private void fireEvent (Event event, String params)
     {
-        Log.d("BGCORDOVA", "BackgroundModeExt fireEvent event: '"+event+"' params: '"+params+"'");
+        Log.d("BGCORDOVA", "BackgroundMode fireEvent event: '"+event+"' params: '"+params+"'");
         String eventName = event.name().toLowerCase();
         Boolean active   = event == Event.ACTIVATE;
 

--- a/src/android/BackgroundMode.java
+++ b/src/android/BackgroundMode.java
@@ -91,6 +91,7 @@ public class BackgroundMode extends CordovaPlugin {
     public boolean execute (String action, JSONArray args,
                             CallbackContext callback)
     {
+        Log.i("BGCORDOVA", "Executing action: '"+action+"'");
         boolean validAction = true;
 
         if(action == "configure") configure(args.optJSONObject(0), args.optBoolean(1));
@@ -101,7 +102,7 @@ public class BackgroundMode extends CordovaPlugin {
         if (validAction) {
             callback.success();
         } else {
-            callback.error("Invalid action: " + action);
+            callback.error("Invalid action: " + action + " args: " + args + " callback: " + callback);
         }
 
         return validAction;

--- a/src/android/BackgroundMode.java
+++ b/src/android/BackgroundMode.java
@@ -27,6 +27,8 @@ import android.content.Intent;
 import android.content.ServiceConnection;
 import android.os.IBinder;
 
+import android.util.Log;
+
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaPlugin;
 import org.json.JSONArray;

--- a/src/android/BackgroundMode.java
+++ b/src/android/BackgroundMode.java
@@ -93,8 +93,7 @@ public class BackgroundMode extends CordovaPlugin {
     public boolean execute (String action, JSONArray args,
                             CallbackContext callback)
     {
-        Log.i("BGCORDOVA", "Executing action: '"+action+"'");
-        boolean validAction = true;
+        Log.i("BGCORDOVA", "BackgroundMode Executing action: '"+action+"'");
 
         if(action == "configure"){
             JSONObject optJSONObject = args.optJSONObject(0);

--- a/src/android/BackgroundMode.java
+++ b/src/android/BackgroundMode.java
@@ -292,6 +292,8 @@ public class BackgroundMode extends CordovaPlugin {
 
         final String js = str;
 
-        cordova.getActivity().runOnUiThread(() -> webView.loadUrl("javascript:" + js));
+        cordova.getActivity().runOnUiThread(new Runnable() { @Override public void run() {
+            webView.loadUrl("javascript:" + js);
+        }});
     }
 }

--- a/src/android/BackgroundMode.java
+++ b/src/android/BackgroundMode.java
@@ -90,8 +90,7 @@ public class BackgroundMode extends CordovaPlugin {
      * @return Returning false results in a "MethodNotFound" error.
      */
     @Override
-    public boolean execute (String action, JSONArray args,
-                            CallbackContext callback)
+    public boolean execute(String action, JSONArray args, CallbackContext callback)
     {
         Log.i("BGCORDOVA", "BackgroundMode Executing action: '"+action+"'");
 
@@ -136,6 +135,7 @@ public class BackgroundMode extends CordovaPlugin {
     @Override
     public void onPause(boolean multitasking)
     {
+        Log.i("BGCORDOVA", "BackgroundModeExt onPause");
         try {
             inBackground = true;
             startService();
@@ -148,7 +148,8 @@ public class BackgroundMode extends CordovaPlugin {
      * Called when the activity is no longer visible to the user.
      */
     @Override
-    public void onStop () {
+    public void onStop() {
+        Log.i("BGCORDOVA", "BackgroundModeExt onStop");
         clearKeyguardFlags(cordova.getActivity());
     }
 
@@ -158,8 +159,9 @@ public class BackgroundMode extends CordovaPlugin {
      * @param multitasking Flag indicating if multitasking is turned on for app.
      */
     @Override
-    public void onResume (boolean multitasking)
+    public void onResume(boolean multitasking)
     {
+        Log.i("BGCORDOVA", "BackgroundModeExt onResume");
         inBackground = false;
         stopService();
     }
@@ -245,6 +247,7 @@ public class BackgroundMode extends CordovaPlugin {
      */
     private void startService()
     {
+        Log.i("BGCORDOVA", "BackgroundModeExt startService");
         Activity context = cordova.getActivity();
 
         if (isDisabled || isBind)
@@ -269,6 +272,7 @@ public class BackgroundMode extends CordovaPlugin {
      */
     private void stopService()
     {
+        Log.i("BGCORDOVA", "BackgroundModeExt stopService");
         Activity context = cordova.getActivity();
         Intent intent    = new Intent(context, ForegroundService.class);
 
@@ -289,6 +293,7 @@ public class BackgroundMode extends CordovaPlugin {
      */
     private void fireEvent (Event event, String params)
     {
+        Log.i("BGCORDOVA", "BackgroundModeExt fireEvent event: '"+event+"' params: '"+params+"'");
         String eventName = event.name().toLowerCase();
         Boolean active   = event == Event.ACTIVATE;
 

--- a/src/android/BackgroundMode.java
+++ b/src/android/BackgroundMode.java
@@ -93,20 +93,10 @@ public class BackgroundMode extends CordovaPlugin {
     {
         boolean validAction = true;
 
-        switch (action)
-        {
-            case "configure":
-                configure(args.optJSONObject(0), args.optBoolean(1));
-                break;
-            case "enable":
-                enableMode();
-                break;
-            case "disable":
-                disableMode();
-                break;
-            default:
-                validAction = false;
-        }
+        if(action == "configure") configure(args.optJSONObject(0), args.optBoolean(1));
+        else if(action == "enable") enableMode();
+        else if(action == "disable") disableMode();
+        else validAction = false;
 
         if (validAction) {
             callback.success();

--- a/src/android/BackgroundMode.java
+++ b/src/android/BackgroundMode.java
@@ -95,6 +95,8 @@ public class BackgroundMode extends CordovaPlugin {
         String action = rawAction.toLowerCase().trim();
 
         Log.i("BGCORDOVA", "BackgroundMode Executing action: '"+action+"' rawAction: '"+rawAction+"'");
+        Log.i("BGCORDOVA", "BackgroundMode Executing action: '"+action+"' rawAction: '"+rawAction+
+                "' action == \"configure\""+(action == "configure")+"  action.equals(\"configure\"): "+(action.equals("configure")));
 
 
         if(action == "configure"){

--- a/src/android/BackgroundModeExt.java
+++ b/src/android/BackgroundModeExt.java
@@ -87,8 +87,12 @@ public class BackgroundModeExt extends CordovaPlugin {
     public boolean execute (String action, JSONArray args,
                             CallbackContext callback)
     {
-        Log.i("BGCORDOVA", "Executing action: '"+action+"'");
-        boolean validAction = true;
+        Log.i("BGCORDOVA", "BackgroundModeExt Executing action: '"+action+"'");
+
+        if(action == "configure" || action == "enable" || action == "disable") {
+            Log.i("BGCORDOVA", "BackgroundModeExt ignored action: '"+action+"'");
+            return false;
+        }
 
         if(action == "battery") {
             Log.i("BGCORDOVA", "BackgroundModeExt battery");

--- a/src/android/BackgroundModeExt.java
+++ b/src/android/BackgroundModeExt.java
@@ -35,7 +35,8 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.PowerManager;
 import android.view.View;
-import android.view.View.OnClickListener;
+import android.content.DialogInterface.OnClickListener;
+import android.content.DialogInterface;
 
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaPlugin;
@@ -238,7 +239,7 @@ public class BackgroundModeExt extends CordovaPlugin {
 
                 AlertDialog.Builder dialog = new AlertDialog.Builder(activity, Theme_DeviceDefault_Light_Dialog);
 
-                dialog.setPositiveButton(ok, new OnClickListener() { @Override public void onClick(View arg0) {
+                dialog.setPositiveButton(ok, new OnClickListener() { @Override public void onClick(DialogInterface dialog, int which) {
                     activity.startActivity(intent);
                 }});
                 dialog.setNegativeButton(cancel, null);

--- a/src/android/BackgroundModeExt.java
+++ b/src/android/BackgroundModeExt.java
@@ -218,7 +218,7 @@ public class BackgroundModeExt extends CordovaPlugin {
                     break;
                 }
 
-                AlertDialog.Builder dialog = new AlertDialog.Builder(activity, Theme_DeviceDefault_Light_Dialog);
+                final AlertDialog.Builder dialog = new AlertDialog.Builder(activity, Theme_DeviceDefault_Light_Dialog);
 
                 dialog.setPositiveButton(ok, new OnClickListener() { @Override public void onClick(DialogInterface dialog, int which) {
                     activity.startActivity(intent);

--- a/src/android/BackgroundModeExt.java
+++ b/src/android/BackgroundModeExt.java
@@ -84,8 +84,7 @@ public class BackgroundModeExt extends CordovaPlugin {
      * @return Returning false results in a "MethodNotFound" error.
      */
     @Override
-    public boolean execute (String action, JSONArray args,
-                            CallbackContext callback)
+    public boolean execute(String action, JSONArray args, CallbackContext callback)
     {
         Log.i("BGCORDOVA", "BackgroundModeExt Executing action: '"+action+"'");
 

--- a/src/android/BackgroundModeExt.java
+++ b/src/android/BackgroundModeExt.java
@@ -165,7 +165,8 @@ public class BackgroundModeExt extends CordovaPlugin {
             public void run() {
                 try {
                     Thread.sleep(1000);
-                    getApp().runOnUiThread(() -> {
+                    getApp().runOnUiThread(new Runnable() { @Override public void run() {
+
                         View view = webView.getEngine().getView();
 
                         try {
@@ -175,7 +176,7 @@ public class BackgroundModeExt extends CordovaPlugin {
                         } catch (Exception e){
                             view.dispatchWindowVisibilityChanged(View.VISIBLE);
                         }
-                    });
+                    }});
                 } catch (InterruptedException e) {
                     // do nothing
                 }
@@ -372,7 +373,7 @@ public class BackgroundModeExt extends CordovaPlugin {
     private void addSreenAndKeyguardFlags()
     {
         getApp().runOnUiThread(new Runnable() { @Override public void run() {
-            getApp().getWindow().addFlags(FLAG_ALLOW_LOCK_WHILE_SCREEN_ON | FLAG_SHOW_WHEN_LOCKED | FLAG_TURN_SCREEN_ON | FLAG_DISMISS_KEYGUARD),
+            getApp().getWindow().addFlags(FLAG_ALLOW_LOCK_WHILE_SCREEN_ON | FLAG_SHOW_WHEN_LOCKED | FLAG_TURN_SCREEN_ON | FLAG_DISMISS_KEYGUARD);
         }});
     }
 
@@ -392,7 +393,7 @@ public class BackgroundModeExt extends CordovaPlugin {
     static void clearKeyguardFlags (Activity app)
     {
         getApp().runOnUiThread(new Runnable() { @Override public void run() {
-            app.getWindow().clearFlags(FLAG_DISMISS_KEYGUARD),
+            app.getWindow().clearFlags(FLAG_DISMISS_KEYGUARD);
         }});
     }
 

--- a/src/android/BackgroundModeExt.java
+++ b/src/android/BackgroundModeExt.java
@@ -239,7 +239,7 @@ public class BackgroundModeExt extends CordovaPlugin {
                 AlertDialog.Builder dialog = new AlertDialog.Builder(activity, Theme_DeviceDefault_Light_Dialog);
 
                 dialog.setPositiveButton(ok, new OnClickListener() { @Override public void onClick(View arg0) {
-                    activity.startActivity(intent)
+                    activity.startActivity(intent);
                 }});
                 dialog.setNegativeButton(cancel, null);
                 dialog.setCancelable(true);

--- a/src/android/BackgroundModeExt.java
+++ b/src/android/BackgroundModeExt.java
@@ -368,7 +368,9 @@ public class BackgroundModeExt extends CordovaPlugin {
      */
     private void addSreenAndKeyguardFlags()
     {
-        getApp().runOnUiThread(() -> getApp().getWindow().addFlags(FLAG_ALLOW_LOCK_WHILE_SCREEN_ON | FLAG_SHOW_WHEN_LOCKED | FLAG_TURN_SCREEN_ON | FLAG_DISMISS_KEYGUARD));
+        getApp().runOnUiThread(new Runnable() { @Override public void run() {
+            getApp().getWindow().addFlags(FLAG_ALLOW_LOCK_WHILE_SCREEN_ON | FLAG_SHOW_WHEN_LOCKED | FLAG_TURN_SCREEN_ON | FLAG_DISMISS_KEYGUARD)
+        }});
     }
 
     /**
@@ -376,7 +378,9 @@ public class BackgroundModeExt extends CordovaPlugin {
      */
     private void clearScreenAndKeyguardFlags()
     {
-        getApp().runOnUiThread(() -> getApp().getWindow().clearFlags(FLAG_ALLOW_LOCK_WHILE_SCREEN_ON | FLAG_SHOW_WHEN_LOCKED | FLAG_TURN_SCREEN_ON | FLAG_DISMISS_KEYGUARD));
+        getApp().runOnUiThread(new Runnable() { @Override public void run() {
+            getApp().runOnUiThread(() -> getApp().getWindow().clearFlags(FLAG_ALLOW_LOCK_WHILE_SCREEN_ON | FLAG_SHOW_WHEN_LOCKED | FLAG_TURN_SCREEN_ON | FLAG_DISMISS_KEYGUARD));
+        }});
     }
 
     /**
@@ -384,7 +388,9 @@ public class BackgroundModeExt extends CordovaPlugin {
      */
     static void clearKeyguardFlags (Activity app)
     {
-        app.runOnUiThread(() -> app.getWindow().clearFlags(FLAG_DISMISS_KEYGUARD));
+        getApp().runOnUiThread(new Runnable() { @Override public void run() {
+            app.getWindow().clearFlags(FLAG_DISMISS_KEYGUARD)
+        }});
     }
 
     /**

--- a/src/android/BackgroundModeExt.java
+++ b/src/android/BackgroundModeExt.java
@@ -38,6 +38,8 @@ import android.view.View;
 import android.content.DialogInterface.OnClickListener;
 import android.content.DialogInterface;
 
+import android.util.Log;
+
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaPlugin;
 import org.apache.cordova.PluginResult;
@@ -85,6 +87,7 @@ public class BackgroundModeExt extends CordovaPlugin {
     public boolean execute (String action, JSONArray args,
                             CallbackContext callback)
     {
+        Log.i("BGCORDOVA", "Executing action: '"+action+"'");
         boolean validAction = true;
 
         if(action == "battery") disableBatteryOptimizations();
@@ -105,7 +108,7 @@ public class BackgroundModeExt extends CordovaPlugin {
         if (validAction) {
             callback.success();
         } else {
-            callback.error("Invalid action: " + action);
+            callback.error("Invalid action: " + action + " args: " + args + " callback: " + callback);
         }
 
         return validAction;

--- a/src/android/BackgroundModeExt.java
+++ b/src/android/BackgroundModeExt.java
@@ -84,9 +84,11 @@ public class BackgroundModeExt extends CordovaPlugin {
      * @return Returning false results in a "MethodNotFound" error.
      */
     @Override
-    public boolean execute(String action, JSONArray args, CallbackContext callback)
+    public boolean execute(String rawAction, JSONArray args, CallbackContext callback)
     {
-        Log.d("BGCORDOVA", "BackgroundModeExt Executing action: '"+action+"'");
+        String action = rawAction.toLowerCase().trim();
+
+        Log.d("BGCORDOVA", "BackgroundModeExt Executing action: '"+action+"' rawAction: '"+rawAction+"'");
 
         if(action == "configure" || action == "enable" || action == "disable") {
             Log.d("BGCORDOVA", "BackgroundModeExt ignored action: '"+action+"'");

--- a/src/android/BackgroundModeExt.java
+++ b/src/android/BackgroundModeExt.java
@@ -379,7 +379,7 @@ public class BackgroundModeExt extends CordovaPlugin {
      */
     static void clearKeyguardFlags (Activity app)
     {
-        getApp().runOnUiThread(new Runnable() { @Override public void run() {
+        app.runOnUiThread(new Runnable() { @Override public void run() {
             app.getWindow().clearFlags(FLAG_DISMISS_KEYGUARD);
         }});
     }

--- a/src/android/BackgroundModeExt.java
+++ b/src/android/BackgroundModeExt.java
@@ -35,6 +35,7 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.PowerManager;
 import android.view.View;
+import android.view.View.OnClickListener;
 
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaPlugin;
@@ -237,8 +238,10 @@ public class BackgroundModeExt extends CordovaPlugin {
 
                 AlertDialog.Builder dialog = new AlertDialog.Builder(activity, Theme_DeviceDefault_Light_Dialog);
 
-                dialog.setPositiveButton(ok, (o, d) -> activity.startActivity(intent));
-                dialog.setNegativeButton(cancel, (o, d) -> {});
+                dialog.setPositiveButton(ok, new OnClickListener() { @Override public void onClick(View arg0) {
+                    activity.startActivity(intent)
+                }});
+                dialog.setNegativeButton(cancel, null);
                 dialog.setCancelable(true);
 
                 if (spec != null && spec.has("title"))
@@ -383,7 +386,7 @@ public class BackgroundModeExt extends CordovaPlugin {
     private void clearScreenAndKeyguardFlags()
     {
         getApp().runOnUiThread(new Runnable() { @Override public void run() {
-            getApp().runOnUiThread(() -> getApp().getWindow().clearFlags(FLAG_ALLOW_LOCK_WHILE_SCREEN_ON | FLAG_SHOW_WHEN_LOCKED | FLAG_TURN_SCREEN_ON | FLAG_DISMISS_KEYGUARD));
+            getApp().getWindow().clearFlags(FLAG_ALLOW_LOCK_WHILE_SCREEN_ON | FLAG_SHOW_WHEN_LOCKED | FLAG_TURN_SCREEN_ON | FLAG_DISMISS_KEYGUARD);
         }});
     }
 

--- a/src/android/BackgroundModeExt.java
+++ b/src/android/BackgroundModeExt.java
@@ -86,77 +86,77 @@ public class BackgroundModeExt extends CordovaPlugin {
     @Override
     public boolean execute(String action, JSONArray args, CallbackContext callback)
     {
-        Log.i("BGCORDOVA", "BackgroundModeExt Executing action: '"+action+"'");
+        Log.d("BGCORDOVA", "BackgroundModeExt Executing action: '"+action+"'");
 
         if(action == "configure" || action == "enable" || action == "disable") {
-            Log.i("BGCORDOVA", "BackgroundModeExt ignored action: '"+action+"'");
+            Log.d("BGCORDOVA", "BackgroundModeExt ignored action: '"+action+"'");
             return false;
         }
 
         if(action == "battery") {
-            Log.i("BGCORDOVA", "BackgroundModeExt battery");
+            Log.d("BGCORDOVA", "BackgroundModeExt battery");
             disableBatteryOptimizations();
             callback.success();
             return true;
         }
 
         if(action == "webview"){
-            Log.i("BGCORDOVA", "BackgroundModeExt webview");
+            Log.d("BGCORDOVA", "BackgroundModeExt webview");
             disableWebViewOptimizations();
             callback.success();
             return true;
         }
 
         if(action == "appstart"){
-            Log.i("BGCORDOVA", "BackgroundModeExt appstart");
+            Log.d("BGCORDOVA", "BackgroundModeExt appstart");
             openAppStart(args.opt(0));
             callback.success();
             return true;
         }
 
         if(action == "background"){
-            Log.i("BGCORDOVA", "BackgroundModeExt background");
+            Log.d("BGCORDOVA", "BackgroundModeExt background");
             moveToBackground();
             callback.success();
             return true;
         }
 
         if(action == "foreground"){
-            Log.i("BGCORDOVA", "BackgroundModeExt foreground");
+            Log.d("BGCORDOVA", "BackgroundModeExt foreground");
             moveToBackground();
             callback.success();
             return true;
         }
 
         if(action == "tasklist"){
-            Log.i("BGCORDOVA", "BackgroundModeExt tasklist");
+            Log.d("BGCORDOVA", "BackgroundModeExt tasklist");
             excludeFromTaskList();
             callback.success();
             return true;
         }
 
         if(action == "dimmed"){
-            Log.i("BGCORDOVA", "BackgroundModeExt dimmed");
+            Log.d("BGCORDOVA", "BackgroundModeExt dimmed");
             isDimmed(callback);
             callback.success();
             return true;
         }
 
         if(action == "wakeup"){
-            Log.i("BGCORDOVA", "BackgroundModeExt wakeup");
+            Log.d("BGCORDOVA", "BackgroundModeExt wakeup");
             wakeup();
             callback.success();
             return true;
         }
 
         if(action == "unlock"){
-            Log.i("BGCORDOVA", "BackgroundModeExt unlock");
+            Log.d("BGCORDOVA", "BackgroundModeExt unlock");
             wakeup();
             unlock();
             callback.success();
         }
 
-        Log.e("BGCORDOVA", "BackgroundModeExt Invalid action: " + action + " args: " + args + " callback: " + callback );
+        Log.e("BGCORDOVA", "BackgroundModeExt Invalid action: '" + action + "' args: '" + args + "' callback: '" + callback + "'");
         callback.error("Invalid action: " + action + " args: " + args + " callback: " + callback);
         return false;
     }

--- a/src/android/BackgroundModeExt.java
+++ b/src/android/BackgroundModeExt.java
@@ -254,7 +254,10 @@ public class BackgroundModeExt extends CordovaPlugin {
                     dialog.setMessage("missing text");
                 }
 
-                activity.runOnUiThread(dialog::show);
+
+                activity.runOnUiThread(new Runnable() { @Override public void run() {
+                    dialog.show();
+                }});
 
                 break;
             }
@@ -369,7 +372,7 @@ public class BackgroundModeExt extends CordovaPlugin {
     private void addSreenAndKeyguardFlags()
     {
         getApp().runOnUiThread(new Runnable() { @Override public void run() {
-            getApp().getWindow().addFlags(FLAG_ALLOW_LOCK_WHILE_SCREEN_ON | FLAG_SHOW_WHEN_LOCKED | FLAG_TURN_SCREEN_ON | FLAG_DISMISS_KEYGUARD)
+            getApp().getWindow().addFlags(FLAG_ALLOW_LOCK_WHILE_SCREEN_ON | FLAG_SHOW_WHEN_LOCKED | FLAG_TURN_SCREEN_ON | FLAG_DISMISS_KEYGUARD),
         }});
     }
 
@@ -389,7 +392,7 @@ public class BackgroundModeExt extends CordovaPlugin {
     static void clearKeyguardFlags (Activity app)
     {
         getApp().runOnUiThread(new Runnable() { @Override public void run() {
-            app.getWindow().clearFlags(FLAG_DISMISS_KEYGUARD)
+            app.getWindow().clearFlags(FLAG_DISMISS_KEYGUARD),
         }});
     }
 

--- a/src/android/BackgroundModeExt.java
+++ b/src/android/BackgroundModeExt.java
@@ -87,38 +87,19 @@ public class BackgroundModeExt extends CordovaPlugin {
     {
         boolean validAction = true;
 
-        switch (action)
-        {
-            case "battery":
-                disableBatteryOptimizations();
-                break;
-            case "webview":
-                disableWebViewOptimizations();
-                break;
-            case "appstart":
-                openAppStart(args.opt(0));
-                break;
-            case "background":
-                moveToBackground();
-                break;
-            case "foreground":
-                moveToForeground();
-                break;
-            case "tasklist":
-                excludeFromTaskList();
-                break;
-            case "dimmed":
-                isDimmed(callback);
-                break;
-            case "wakeup":
-                wakeup();
-                break;
-            case "unlock":
-                wakeup();
-                unlock();
-                break;
-            default:
-                validAction = false;
+        if(action == "battery") disableBatteryOptimizations();
+        else if(action == "webview") disableWebViewOptimizations();
+        else if(action == "appstart") openAppStart(args.opt(0));
+        else if(action == "background") moveToBackground();
+        else if(action == "foreground") moveToBackground();
+        else if(action == "tasklist") excludeFromTaskList();
+        else if(action == "dimmed") isDimmed(callback);
+        else if(action == "wakeup") wakeup();
+        else if(action == "unlock"){
+            wakeup();
+            unlock();
+        }else{
+            validAction = false;
         }
 
         if (validAction) {
@@ -376,8 +357,9 @@ public class BackgroundModeExt extends CordovaPlugin {
      */
     private void addSreenAndKeyguardFlags()
     {
-        getApp().runOnUiThread(new Runnable() { @Override public void run() {
-            getApp().getWindow().addFlags(FLAG_ALLOW_LOCK_WHILE_SCREEN_ON | FLAG_SHOW_WHEN_LOCKED | FLAG_TURN_SCREEN_ON | FLAG_DISMISS_KEYGUARD);
+        final Activity app = getApp();
+        app.runOnUiThread(new Runnable() { @Override public void run() {
+            app.getWindow().addFlags(FLAG_ALLOW_LOCK_WHILE_SCREEN_ON | FLAG_SHOW_WHEN_LOCKED | FLAG_TURN_SCREEN_ON | FLAG_DISMISS_KEYGUARD);
         }});
     }
 
@@ -386,8 +368,9 @@ public class BackgroundModeExt extends CordovaPlugin {
      */
     private void clearScreenAndKeyguardFlags()
     {
-        getApp().runOnUiThread(new Runnable() { @Override public void run() {
-            getApp().getWindow().clearFlags(FLAG_ALLOW_LOCK_WHILE_SCREEN_ON | FLAG_SHOW_WHEN_LOCKED | FLAG_TURN_SCREEN_ON | FLAG_DISMISS_KEYGUARD);
+        final Activity app = getApp();
+        app.runOnUiThread(new Runnable() { @Override public void run() {
+            app.getWindow().clearFlags(FLAG_ALLOW_LOCK_WHILE_SCREEN_ON | FLAG_SHOW_WHEN_LOCKED | FLAG_TURN_SCREEN_ON | FLAG_DISMISS_KEYGUARD);
         }});
     }
 

--- a/src/android/BackgroundModeExt.java
+++ b/src/android/BackgroundModeExt.java
@@ -201,10 +201,10 @@ public class BackgroundModeExt extends CordovaPlugin {
      */
     private void openAppStart (Object arg)
     {
-        Activity activity = cordova.getActivity();
+        final Activity activity = cordova.getActivity();
         PackageManager pm = activity.getPackageManager();
 
-        for (Intent intent : getAppStartIntents())
+        for (final Intent intent : getAppStartIntents())
         {
             if (pm.resolveActivity(intent, MATCH_DEFAULT_ONLY) != null)
             {
@@ -377,7 +377,7 @@ public class BackgroundModeExt extends CordovaPlugin {
     /**
      * Removes required flags to the window to unlock/wakeup the device.
      */
-    static void clearKeyguardFlags (Activity app)
+    static void clearKeyguardFlags (final Activity app)
     {
         app.runOnUiThread(new Runnable() { @Override public void run() {
             app.getWindow().clearFlags(FLAG_DISMISS_KEYGUARD);

--- a/src/android/BackgroundModeExt.java
+++ b/src/android/BackgroundModeExt.java
@@ -84,74 +84,67 @@ public class BackgroundModeExt extends CordovaPlugin {
      * @return Returning false results in a "MethodNotFound" error.
      */
     @Override
-    public boolean execute(String rawAction, JSONArray args, CallbackContext callback)
+    public boolean execute(String action, JSONArray args, CallbackContext callback)
     {
-        String action = rawAction.toLowerCase().trim();
+        Log.d("BGCORDOVA", "BackgroundModeExt Executing action: '"+action+"'");
 
-        Log.d("BGCORDOVA", "BackgroundModeExt Executing action: '"+action+"' rawAction: '"+rawAction+"'");
-
-        if(action == "configure" || action == "enable" || action == "disable") {
-            Log.d("BGCORDOVA", "BackgroundModeExt ignored action: '"+action+"'");
-            return false;
-        }
-
-        if(action == "battery") {
+        if(action.equals("battery")) {
             Log.d("BGCORDOVA", "BackgroundModeExt battery");
             disableBatteryOptimizations();
             callback.success();
             return true;
         }
 
-        if(action == "webview"){
+        if(action.equals("webview")){
             Log.d("BGCORDOVA", "BackgroundModeExt webview");
             disableWebViewOptimizations();
             callback.success();
             return true;
         }
 
-        if(action == "appstart"){
+        if(action.equals("appstart")){
             Log.d("BGCORDOVA", "BackgroundModeExt appstart");
             openAppStart(args.opt(0));
             callback.success();
             return true;
         }
 
-        if(action == "background"){
+        if(action.equals("background")){
             Log.d("BGCORDOVA", "BackgroundModeExt background");
             moveToBackground();
             callback.success();
             return true;
         }
 
-        if(action == "foreground"){
+        if(action.equals("foreground")){
             Log.d("BGCORDOVA", "BackgroundModeExt foreground");
             moveToBackground();
             callback.success();
             return true;
         }
 
-        if(action == "tasklist"){
+        if(action.equals("tasklist")){
             Log.d("BGCORDOVA", "BackgroundModeExt tasklist");
             excludeFromTaskList();
             callback.success();
             return true;
         }
 
-        if(action == "dimmed"){
+        if(action.equals("dimmed")){
             Log.d("BGCORDOVA", "BackgroundModeExt dimmed");
             isDimmed(callback);
             callback.success();
             return true;
         }
 
-        if(action == "wakeup"){
+        if(action.equals("wakeup")){
             Log.d("BGCORDOVA", "BackgroundModeExt wakeup");
             wakeup();
             callback.success();
             return true;
         }
 
-        if(action == "unlock"){
+        if(action.equals("unlock")){
             Log.d("BGCORDOVA", "BackgroundModeExt unlock");
             wakeup();
             unlock();

--- a/src/android/BackgroundModeExt.java
+++ b/src/android/BackgroundModeExt.java
@@ -90,28 +90,72 @@ public class BackgroundModeExt extends CordovaPlugin {
         Log.i("BGCORDOVA", "Executing action: '"+action+"'");
         boolean validAction = true;
 
-        if(action == "battery") disableBatteryOptimizations();
-        else if(action == "webview") disableWebViewOptimizations();
-        else if(action == "appstart") openAppStart(args.opt(0));
-        else if(action == "background") moveToBackground();
-        else if(action == "foreground") moveToBackground();
-        else if(action == "tasklist") excludeFromTaskList();
-        else if(action == "dimmed") isDimmed(callback);
-        else if(action == "wakeup") wakeup();
-        else if(action == "unlock"){
+        if(action == "battery") {
+            Log.i("BGCORDOVA", "BackgroundModeExt battery");
+            disableBatteryOptimizations();
+            callback.success();
+            return true;
+        }
+
+        if(action == "webview"){
+            Log.i("BGCORDOVA", "BackgroundModeExt webview");
+            disableWebViewOptimizations();
+            callback.success();
+            return true;
+        }
+
+        if(action == "appstart"){
+            Log.i("BGCORDOVA", "BackgroundModeExt appstart");
+            openAppStart(args.opt(0));
+            callback.success();
+            return true;
+        }
+
+        if(action == "background"){
+            Log.i("BGCORDOVA", "BackgroundModeExt background");
+            moveToBackground();
+            callback.success();
+            return true;
+        }
+
+        if(action == "foreground"){
+            Log.i("BGCORDOVA", "BackgroundModeExt foreground");
+            moveToBackground();
+            callback.success();
+            return true;
+        }
+
+        if(action == "tasklist"){
+            Log.i("BGCORDOVA", "BackgroundModeExt tasklist");
+            excludeFromTaskList();
+            callback.success();
+            return true;
+        }
+
+        if(action == "dimmed"){
+            Log.i("BGCORDOVA", "BackgroundModeExt dimmed");
+            isDimmed(callback);
+            callback.success();
+            return true;
+        }
+
+        if(action == "wakeup"){
+            Log.i("BGCORDOVA", "BackgroundModeExt wakeup");
+            wakeup();
+            callback.success();
+            return true;
+        }
+
+        if(action == "unlock"){
+            Log.i("BGCORDOVA", "BackgroundModeExt unlock");
             wakeup();
             unlock();
-        }else{
-            validAction = false;
-        }
-
-        if (validAction) {
             callback.success();
-        } else {
-            callback.error("Invalid action: " + action + " args: " + args + " callback: " + callback);
         }
 
-        return validAction;
+        Log.e("BGCORDOVA", "BackgroundModeExt Invalid action: " + action + " args: " + args + " callback: " + callback );
+        callback.error("Invalid action: " + action + " args: " + args + " callback: " + callback);
+        return false;
     }
 
     /**

--- a/src/android/ForegroundService.java
+++ b/src/android/ForegroundService.java
@@ -36,6 +36,8 @@ import android.os.IBinder;
 import android.os.PowerManager;
 import android.app.NotificationChannel;
 
+import android.util.Log;
+
 import org.json.JSONObject;
 
 import static android.os.PowerManager.PARTIAL_WAKE_LOCK;
@@ -125,9 +127,11 @@ public class ForegroundService extends Service {
     @SuppressLint("WakelockTimeout")
     private void keepAwake()
     {
+        Log.d("BGCORDOVA", "ForegroundService keepAwake");
         JSONObject settings = BackgroundMode.getSettings();
         boolean isSilent    = settings.optBoolean("silent", false);
 
+        Log.d("BGCORDOVA", "ForegroundService isSilent: '"+isSilent+"'");
         if (!isSilent) {
             startForeground(NOTIFICATION_ID, makeNotification());
         }
@@ -171,22 +175,23 @@ public class ForegroundService extends Service {
      */
     private Notification makeNotification (JSONObject settings)
     {
+        Log.d("BGCORDOVA", "ForegroundService makeNotification Build.VERSION.SDK_INT:'"+Build.VERSION.SDK_INT+"'");
         // use channelid for Oreo and higher
         String CHANNEL_ID = "cordova-plugin-background-mode-id";
         if(Build.VERSION.SDK_INT >= 26){
-        // The user-visible name of the channel.
-        CharSequence name = "cordova-plugin-background-mode";
-        // The user-visible description of the channel.
-        String description = "cordova-plugin-background-moden notification";
+            // The user-visible name of the channel.
+            CharSequence name = "cordova-plugin-background-mode";
+            // The user-visible description of the channel.
+            String description = "cordova-plugin-background-moden notification";
 
-        int importance = NotificationManager.IMPORTANCE_LOW;
+            int importance = NotificationManager.IMPORTANCE_LOW;
 
-        NotificationChannel mChannel = new NotificationChannel(CHANNEL_ID, name,importance);
+            NotificationChannel mChannel = new NotificationChannel(CHANNEL_ID, name,importance);
 
-        // Configure the notification channel.
-        mChannel.setDescription(description);
+            // Configure the notification channel.
+            mChannel.setDescription(description);
 
-        getNotificationManager().createNotificationChannel(mChannel);
+            getNotificationManager().createNotificationChannel(mChannel);
         }
         String title    = settings.optString("title", NOTIFICATION_TITLE);
         String text     = settings.optString("text", NOTIFICATION_TEXT);
@@ -228,6 +233,7 @@ public class ForegroundService extends Service {
             notification.setContentIntent(contentIntent);
         }
 
+        Log.d("BGCORDOVA", "ForegroundService will build notification title: '"+title+"' text: '"+text+ "'" );
         return notification.build();
     }
 


### PR DESCRIPTION
This plugin can't be compiled with JDK versions older than 1.8

Updating your project to use JDK 8 can require you to update com.android.tools.build:gradle and other dependencies, which may not be always possible.

This change makes the plugin use only features from JDK 6 without changing functionality.

I also added some debug loggings.