### PR TITLE
Enable multiple audios on IOS platform.

### DIFF
--- a/src/ios/APPBackgroundMode.m
+++ b/src/ios/APPBackgroundMode.m
@@ -173,6 +173,7 @@ NSString* const kAPPBackgroundEventDeactivate = @"deactivate";
     // Play music even in background and dont stop playing music
     // even another app starts playing sound
     [session setCategory:AVAudioSessionCategoryPlayback
+                   withOptions:AVAudioSessionCategoryOptionMixWithOthers
                    error:NULL];
 
     // Active the audio session


### PR DESCRIPTION
Enable multiple audios on the same AVAudioSession, because in audios's app the current plugin implementation don't allow play the "main" audio, instead, it plays the beep with volume 0, giving the feeling that the app is not working when the app goes to background.

Inspired heavily in cordova-plugin-background-mode-appstronauts fork (https://github.com/ionic-team/cordova-plugin-ionic-webview/issues/451#issuecomment-542249396)