### PR TITLE
Resolved - When Application Launch, Music Player Stops iOS

### DIFF
--- a/src/ios/APPBackgroundMode.m
+++ b/src/ios/APPBackgroundMode.m
@@ -174,6 +174,9 @@ NSString* const kAPPBackgroundEventDeactivate = @"deactivate";
     // even another app starts playing sound
     [session setCategory:AVAudioSessionCategoryPlayback
                    error:NULL];
+  
+    [session setCategory:AVAudioSessionCategoryAmbient
+                   error:NULL];
 
     // Active the audio session
     [session setActive:YES error:NULL];


### PR DESCRIPTION
When Application Launch, Music Player Stops in iOS. Now both app music and background music will play.