### PR TITLE
Added "Lock" method to return the device to base state

### DIFF
--- a/src/android/BackgroundModeExt.java
+++ b/src/android/BackgroundModeExt.java
@@ -115,6 +115,9 @@ public class BackgroundModeExt extends CordovaPlugin {
                 wakeup();
                 unlock();
                 break;
+            case "lock":
+                clearScreenAndKeyguardFlags();
+                break;
             default:
                 validAction = false;
         }

--- a/www/background-mode.js
+++ b/www/background-mode.js
@@ -292,6 +292,19 @@ exports.unlock = function()
 };
 
 /**
+ * Returns the device to the state before executing unlock.
+ *
+ * @return [ Void ]
+ */
+exports.lock = function()
+{
+    if (this._isAndroid)
+    {
+        cordova.exec(null, null, 'BackgroundModeExt', 'lock', []);
+    }
+};
+
+/**
  * If the mode is enabled or disabled.
  *
  * @return [ Boolean ]


### PR DESCRIPTION
When we execute "unlock" we set some flags to true:

FLAG_ALLOW_LOCK_WHILE_SCREEN_ON
FLAG_SHOW_WHEN_LOCKED
FLAG_TURN_SCREEN_ON
FLAG_DISMISS_KEYGUARD

And if we have our app in foreground and turn the screen off, we see our app.

I've added a method to clear these flags just in case we don't want that.
