### PR TITLE
Fix app killing itself when opening deep links

### DIFF
--- a/src/android/BackgroundMode.java
+++ b/src/android/BackgroundMode.java
@@ -160,7 +160,6 @@ public class BackgroundMode extends CordovaPlugin {
     public void onDestroy()
     {
         stopService();
-        android.os.Process.killProcess(android.os.Process.myPid());
     }
 
     /**


### PR DESCRIPTION
When opening a deep link this plugin is loaded twice on the same process, so we cannot kill the app when destroying the first plugin.

This line was first added by https://github.com/katzer/cordova-plugin-background-mode/pull/304
However the issue this was intended to solve was likely fixed by removing the launchMode singleInstance (already merged), as explained in here: https://github.com/katzer/cordova-plugin-background-mode/issues/261#issuecomment-287983655