### PR TITLE
Use default ic_launcher as fallback - Android

### DIFF
--- a/src/android/ForegroundService.java
+++ b/src/android/ForegroundService.java
@@ -286,7 +286,11 @@ public class ForegroundService extends Service {
         if (resId == 0) {
             resId = res.getIdentifier("icon", type, pkgName);
         }
-
+ 
+        if (resId == 0) {
+            resId = res.getIdentifier("ic_launcher", type, pkgName);
+        }    
+     
         return resId;
     }
 


### PR DESCRIPTION
Notification setup fails for background mode without any error triggered when 'resId' remains at value 0 due to missing valid icon ressource.
This involves the notification to appear as "[application name] is running in background" and when you click on notification it opens the "App info" instad of the application itself.
This fix makes the final icon fallback to be the launcher icon.