### PR TITLE
fix android issue api 31 and when moving to back not going to home page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-background-mode",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Prevent apps from going to sleep in background.",
   "cordova": {
     "id": "cordova-plugin-background-mode",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-background-mode",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Prevent apps from going to sleep in background.",
   "cordova": {
     "id": "cordova-plugin-background-mode",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-background-mode",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "description": "Prevent apps from going to sleep in background.",
   "cordova": {
     "id": "cordova-plugin-background-mode",

--- a/package.json
+++ b/package.json
@@ -22,16 +22,11 @@
     "cordova-android",
     "cordova-browser"
   ],
-  "engines": [
+  "engines": 
     {
-      "name": "cordova",
-      "version": ">=3.0.0"
+     "cordova": ">=3.0.0",
+      "android-sdk": ">=16"
     },
-    {
-      "name": "android-sdk",
-      "version": ">=16"
-    }
-  ],
   "author": "Sebastián Katzer",
   "license": "Apache 2.0",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/katzer/cordova-plugin-background-mode.git"
+    "url": "git+https://github.com/alindzon/cordova-plugin-background-mode.git"
   },
   "keywords": [
     "appplant",
@@ -27,10 +27,10 @@
      "cordova": ">=3.0.0",
       "android-sdk": ">=16"
     },
-  "author": "Sebastián Katzer",
+  "author": "by Sebastián Katzer forked by Andrew Lindozn",
   "license": "Apache 2.0",
   "bugs": {
-    "url": "https://github.com/katzer/cordova-plugin-background-mode/issues"
+    "url": "https://github.com/alindzon/cordova-plugin-background-mode/issues"
   },
-  "homepage": "https://github.com/katzer/cordova-plugin-background-mode#readme"
+  "homepage": "https://github.com/alindzon/cordova-plugin-background-mode#readme"
 }

--- a/plugin.xml
+++ b/plugin.xml
@@ -3,7 +3,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
         id="cordova-plugin-background-mode"
-        version="0.7.5">
+        version="0.7.6">
 
     <name>BackgroundMode</name>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -3,7 +3,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
         id="cordova-plugin-background-mode"
-        version="0.7.4">
+        version="0.7.5">
 
     <name>BackgroundMode</name>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -3,7 +3,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
         id="cordova-plugin-background-mode"
-        version="0.7.3">
+        version="0.7.4">
 
     <name>BackgroundMode</name>
 

--- a/src/android/BackgroundModeExt.java
+++ b/src/android/BackgroundModeExt.java
@@ -133,14 +133,16 @@ public class BackgroundModeExt extends CordovaPlugin {
      */
     private void moveToBackground()
     {
-        Intent intent = new Intent(Intent.ACTION_MAIN);
+     moveTaskToBack(true);
+       /**  Intent intent = new Intent(Intent.ACTION_MAIN);
 
-      /**
+     
        * test without this to see if previous app goes to foreground
        *intent.addCategory(Intent.CATEGORY_HOME);
-       */
+       
 
         getApp().startActivity(intent);
+        */
     }
 
     /**

--- a/src/android/BackgroundModeExt.java
+++ b/src/android/BackgroundModeExt.java
@@ -133,7 +133,8 @@ public class BackgroundModeExt extends CordovaPlugin {
      */
     private void moveToBackground()
     {
-     moveTaskToBack(true);
+     Activity  app = getApp();
+     app.moveTaskToBack(true);
        /**  Intent intent = new Intent(Intent.ACTION_MAIN);
 
      

--- a/src/android/BackgroundModeExt.java
+++ b/src/android/BackgroundModeExt.java
@@ -135,7 +135,10 @@ public class BackgroundModeExt extends CordovaPlugin {
     {
         Intent intent = new Intent(Intent.ACTION_MAIN);
 
-        intent.addCategory(Intent.CATEGORY_HOME);
+      /**
+       * test without this to see if previous app goes to foreground
+       *intent.addCategory(Intent.CATEGORY_HOME);
+       */
 
         getApp().startActivity(intent);
     }

--- a/src/android/ForegroundService.java
+++ b/src/android/ForegroundService.java
@@ -222,7 +222,7 @@ public class ForegroundService extends Service {
             intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
             PendingIntent contentIntent = PendingIntent.getActivity(
                     context, NOTIFICATION_ID, intent,
-                    PendingIntent.FLAG_UPDATE_CURRENT);
+                    PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_MUTABLE);
 
 
             notification.setContentIntent(contentIntent);


### PR DESCRIPTION
The android issue had to be fixed in AndroidService.java with | PendingIntent.FLAG_MUTABLE);

The changes in src/android/BackgroundModeExt.java were because it makes more sense to restore the previous foreground app than to go to the home page when moving the app to the background in code.